### PR TITLE
docs: Fix Typos and Update Broken Links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ This bug is a good example of how implementing a secure cryptographic protocol c
 
 Related Vulnerabilities: 1. Under-constrained Circuits, 2. Nondeterministic Circuits
 
-Identified By: [botdad](https://twitter.com/0xB07DAD)
+Identified By: [botdad](https://github.com/botdad)
 
 StealthDrop requires users post a nullifier on-chain when they claim an airdrop. If they try to claim the airdrop twice, the second claim will fail. However, ECDSA signatures were used as the nullifier and these signatures are nondeterministic. Therefore different signatures were valid nullifiers for a single claim and users could claim an airdrop multiple times by sending the different valid signatures.
 
@@ -1031,7 +1031,7 @@ In order to prove the (Key, Value) inclusion in the SMT, the state machine repre
 
 As the tree is sparse, the leaf level is not necessarily equal to the key bits length, that means that as soon as the leaf is inserted into the tree, the remaining part of the key (rkey) is being encoded into the leaf value.
 
-The inclusion check algorithm consists of two parts (reference link: https://wiki.polygon.technology/docs/zkEVM/zkProver/basic-smt-ops):
+The inclusion check algorithm consists of two parts (reference link: https://docs.polygon.technology/zkEVM/concepts/sparse-merkle-trees/basic-smt-ops):
 
 1. Checking The Root - is done as a generic Merkel Tree root check by climbing from the leaf to the root using sibling hashes.
 
@@ -1073,7 +1073,7 @@ Nonetheless, it can not be abused straightforwardly; a number of limitations mus
 Limitations overview:
 
 In the Storage SM, The key is broken down into four registers: rkey0,..,rkey3 and the path is constructed by cycling the consecutive bits of that registers:
-`path = [rKey0_0, rKey1_0, rKey2_0, rKey3_0, rKey0_1, ... ]` (reference link: https://wiki.polygon.technology/docs/zkEVM/zkProver/construct-key-path)
+`path = [rKey0_0, rKey1_0, rKey2_0, rKey3_0, rKey0_1, ... ]` (reference link: https://docs.polygon.technology/zkEVM/architecture/zkprover/storage-state-machine/construct-key-path/)
 
 Thus, in order to reconstruct the key from the bits, the corresponding rkey polynomial needs to be prepended with that bit:
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you would like to add a "bug in the wild" or a "common vulnerability", there 
  20. [Polygon zkEVM: Missing Remainder Constraint](#polygon-zkevm-1)
  21. [Polygon zkEVM: Missing constraint in PIL leading to proving fake inclusion in the SMT](#hexens-polygonzkevm-1)
  22. [Polygon zkEVM: Incorrect CTX assignation leading to addition of random amount of ether to the sequencer balance](#hexens-polygonzkevm-2)
- 23. [Polygon zkEVM: Missing constraint in PIL leading to execution flow hijak](#hexens-polygonzkevm-3)
+ 23. [Polygon zkEVM: Missing constraint in PIL leading to execution flow hijack](#hexens-polygonzkevm-3)
  24. [Zendoo: Missing Polynomial Normalization after Arithmetic Operations](#zendoo-polynomial-1)
  25. [Aleo: Non-Committing Encryption Used in InputID::Private](#aleo-encryption-1)
  26. [Light Protocol: Modification of shared state is not an atomic operation](#light-protocol-1)
@@ -1240,7 +1240,7 @@ The Fix of this issue is to change the `identity.zkasm` code to save the `origin
 1. [Hexens Audit Report](https://github.com/Hexens/Smart-Contract-Review-Public-Reports/blob/main/Hexens_Polygon_zkEVM_PUBLIC_27.02.23.pdf)
 2. [Fix Commit](https://github.com/0xPolygonHermez/zkevm-rom/commit/2ddeffbed7c022e04032e6d56ed6c6fb14cc38dc#diff-388aa2d51760e0d46ac2b556f46a39e7e893b223b4c3604fa804e29557078ffa)
 
-## <a name="hexens-polygonzkevm-3">23. Polygon zkEVM: Missing constraint in PIL leading to execution flow hijak</a>
+## <a name="hexens-polygonzkevm-3">23. Polygon zkEVM: Missing constraint in PIL leading to execution flow hijack</a>
 
 **Summary**
 


### PR DESCRIPTION
### Describe your changes
Fixed typos and broken links in `README.md`.

### Related Issue [if applicable]
Issue: # (none reported)

### Common Vulnerabilities Addition Checklist [if adding a new common vulnerability]
- [ ] Added example code of the vulnerability
- [ ] Provided an explanation of how the vulnerability works
- [ ] Included an attack scenario section if applicable
- [ ] Included preventative techniques section if applicable

### Bugs in the Wild Addition Checklist [if adding a new bug found in the wild]
- [ ] Added code of the vulnerability if available
- [ ] Added the following sections: Summary, Background, The Vulnerability, The Fix, and References
- [ ] Summary includes related common vulnerabilities and the identifier of whoever found the bug
- [ ] References include links to bug descriptions, such as Twitter threads, GitHub issues, or commits

ex:
https://wiki.polygon.technology/docs/zkEVM/zkProver/basic-smt-ops - This link points to an outdated or non-existent page.
https://docs.polygon.technology/zkEVM/concepts/sparse-merkle-trees/basic-smt-ops -  This link now directs to the correct documentation page.