### PR TITLE
fix: typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -837,7 +837,7 @@ The Dusk Network is a privacy-oriented blockchain that relies on zk proofs. In o
 
 ZK SNARKs are useful for both their succinctness and their zero knowledge. The main pieces of the Plonk protocol allows the proofs to be succinct, and it only takes a few small steps to make the protocol zero knowledge as well. Making the protocol zero knowledge means that an attacker cannot look at a proof and then derive the witness used to generate that proof.
 
-In Plonk one of the few steps that makes the protocol zero knowledge is adding blinding factors to the prover polynomials. Essentially, the prover shifts the polynomials by a secret amount while still keeping the proof verficiation successful. These secret shifts prevent others from extracting the witness from the proof.
+In Plonk one of the few steps that makes the protocol zero knowledge is adding blinding factors to the prover polynomials. Essentially, the prover shifts the polynomials by a secret amount while still keeping the proof verification successful. These secret shifts prevent others from extracting the witness from the proof.
 
 **The Vulnerability**
 
@@ -892,7 +892,7 @@ require(_inputs[4]<zokratesPrime, "Input too large - possible overflow attack");
 2. [Github Fix](https://github.com/EYBlockchain/nightfall/pull/96)
 
 
-## <a name="summa-1">19. Summa: Unconstrained Constants Assignemnt </a>
+## <a name="summa-1">19. Summa: Unconstrained Constants Assignment </a>
 
 **Summary**
 
@@ -935,7 +935,7 @@ Later on the circuit would have an assignment function to be called during witne
     )?;
 ```
 
-However, this design erroneusly suppose that any prover would be using the assignment function provided by the library. A malicious prover can simply take the function and modify it to assign a different `Value::known` to `check`, even 0. This would cause the circuit to generate a valid proof for a `lhs` that is greater than the `rhs`.
+However, this design erroneously suppose that any prover would be using the assignment function provided by the library. A malicious prover can simply take the function and modify it to assign a different `Value::known` to `check`, even 0. This would cause the circuit to generate a valid proof for a `lhs` that is greater than the `rhs`.
 
 **The Fix**
 


### PR DESCRIPTION
## Description

This pull request fixes several typographical errors in the `README.md` file to improve clarity and maintain consistency in the documentation.

---

## Describe your changes

- Corrected a typo in the description of blinding factors used in Plonk protocol (`"verficiation"` → `"verification"`).
- Fixed a typo in the title of a vulnerability section (`"Assignemnt"` → `"Assignment"`).
- Addressed a typo in the explanation of the vulnerability regarding assignment functions (`"erroneusly"` → `"erroneously"`).

These changes ensure the document is professional and easy to understand.

---

## Related Issue [if applicable]

Issue: N/A

---

## Common Vulnerabilities Addition Checklist [if adding a new common vulnerability]

Not applicable.

---

## Bugs in the Wild Addition Checklist [if adding a new bug found in the wild]

Not applicable.

---

- [x] Allow edits by maintainers

This pull request aligns with the repository's guidelines and improves the overall quality of the documentation.
