### PR TITLE
Typo Fix in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -837,7 +837,7 @@ The Dusk Network is a privacy-oriented blockchain that relies on zk proofs. In o
 
 ZK SNARKs are useful for both their succinctness and their zero knowledge. The main pieces of the Plonk protocol allows the proofs to be succinct, and it only takes a few small steps to make the protocol zero knowledge as well. Making the protocol zero knowledge means that an attacker cannot look at a proof and then derive the witness used to generate that proof.
 
-In Plonk one of the few steps that makes the protocol zero knowledge is adding blinding factors to the prover polynomials. Essentially, the prover shifts the polynomials by a secret amount while still keeping the proof verficiation successful. These secret shifts prevent others from extracting the witness from the proof.
+In Plonk one of the few steps that makes the protocol zero knowledge is adding blinding factors to the prover polynomials. Essentially, the prover shifts the polynomials by a secret amount while still keeping the proof verification successful. These secret shifts prevent others from extracting the witness from the proof.
 
 **The Vulnerability**
 

--- a/README.md
+++ b/README.md
@@ -935,7 +935,7 @@ Later on the circuit would have an assignment function to be called during witne
     )?;
 ```
 
-However, this design erroneusly suppose that any prover would be using the assignment function provided by the library. A malicious prover can simply take the function and modify it to assign a different `Value::known` to `check`, even 0. This would cause the circuit to generate a valid proof for a `lhs` that is greater than the `rhs`.
+However, this design erroneously suppose that any prover would be using the assignment function provided by the library. A malicious prover can simply take the function and modify it to assign a different `Value::known` to `check`, even 0. This would cause the circuit to generate a valid proof for a `lhs` that is greater than the `rhs`.
 
 **The Fix**
 


### PR DESCRIPTION
## Pull Request: Typo Fix in README.md

### Description  
This PR fixes minor typos in the `README.md` file.

---

### Changes  
#### Before  
1. **Line 837**  
   > *"keeping the proof **verficiation** successful."*  
2. **Line 935**  
   > *"this design **erroneusly** suppose..."*

#### After  
1. **Line 837**  
   > *"keeping the proof **verification** successful."*  
2. **Line 935**  
   > *"this design **erroneously** suppose..."*

---

### Summary of Changes  
- **2 additions**: Corrected spelling mistakes.  
- **2 deletions**: Removed incorrect typos.  

---


